### PR TITLE
Initial 4.x compatibility

### DIFF
--- a/module.json
+++ b/module.json
@@ -44,7 +44,7 @@
         "compatibility": {
           "minimum": "3",
           "verified": "3.3.1",
-          "maximum": "3.3.999"
+          "maximum": "4.9.99"
         }
       }
     ]

--- a/scripts/individualRolls.js
+++ b/scripts/individualRolls.js
@@ -1,5 +1,5 @@
 import { moduleName } from "./mobAttack.js";
-import { endGroupedMobTurn, getDamageFormulaAndType, sendChatMessage, getAttackBonus, callMidiMacro } from "./utils.js";
+import { endGroupedMobTurn, getDamageFormulaAndType, sendChatMessage, getAttackBonus, callMidiMacro, getAttackData } from "./utils.js";
 
 export async function rollMobAttackIndividually(data) {
 	// Temporarily disable DSN 3d dice from rolling, per settings
@@ -216,6 +216,9 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 		}
 	}
 
+	const FoundryDie = foundry.dice?.terms?.Die || Die;
+	const attackData = getAttackData(weaponData);
+
 	if (numHitAttacks != 0) {
 		// midi active
 		if (midi_QOL_Active) {
@@ -225,14 +228,14 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 
 					let diceFormula = diceFormulas.join(" + ");
 					let damageType = damageTypes.join(", ");
-					let damageRoll = new Roll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod });
+					let damageRoll = new CONFIG.Dice.DamageRoll(diceFormula, { mod: weaponData.actor.system.abilities[attackData.ability].mod });
 
 					if(numCrits > 0) {
 						// Add critical damage dice on each successful attack, up to the number of crits
 						let critDice = [], critDie;
 						let damageRollDiceTerms = damageRoll.terms.filter(t => t.number > 0 && t.faces > 0);
 						for (let term of damageRollDiceTerms) {
-							critDie = new Die({ number: term.number, faces: term.faces });
+							critDie = new FoundryDie({ number: term.number, faces: term.faces });
 							critDice.push(critDie);
 						}
 						for (let i = 0; i < critDice.length; i++) {
@@ -261,7 +264,7 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 						damageRoll,
 						{
 							flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})${(numCrits > 0) ? ` (${game.i18n.localize("MAT.critIncluded")})` : ``}`,
-							itemData: weaponData,
+							item: weaponData,
 							itemCardId: `new`
 						}
 					);
@@ -279,13 +282,13 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 
 				let diceFormula = diceFormulas.join(" + ");
 				let damageType = damageTypes.join(", ");
-				let damageRoll = new Roll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod });
+				let damageRoll = new CONFIG.Dice.DamageRoll(diceFormula, { mod: weaponData.actor.system.abilities[attackData.ability].mod });
 
 				// Add critical damage dice
 				let critDice = [], critDie;
 				let damageRollDiceTerms = damageRoll.terms.filter(t => t.number > 0 && t.faces > 0);
 				for (let term of damageRollDiceTerms) {
-					critDie = new Die({ number: term.number, faces: term.faces });
+					critDie = new FoundryDie({ number: term.number, faces: term.faces });
 					critDice.push(critDie);
 				}
 				await damageRoll.alter(numHitAttacks, 0, { multiplyNumeric: true });
@@ -316,13 +319,13 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 					damageRoll,
 					{
 						flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})${(numCrits > 0) ? ` (${game.i18n.localize("MAT.critIncluded")})` : ``}`,
-						itemData: weaponData,
+						item: weaponData,
 						itemCardId: `new`
 					}
 				);
 
 				// prepare data for Midi's On Use Macro feature
-				if (game.settings.get(moduleName, "enableMidiOnUseMacro") && getProperty(weaponData, "flags.midi-qol.onUseMacroName")) {
+				if (game.settings.get(moduleName, "enableMidiOnUseMacro") && foundry.utils.getProperty(weaponData, "flags.midi-qol.onUseMacroName")) {
 					await new Promise(resolve => setTimeout(resolve, 300));
 					const macroData = {
 						actor: weaponData.actor,
@@ -353,7 +356,7 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 						uuid: workflow.uuid,
 						rollData: weaponData.actor.getRollData(),
 						tag: "OnUse",
-						concentrationData: getProperty(weaponData.actor.flags, "midi-qol.concentration-data"),
+						concentrationData: foundry.utils.getProperty(weaponData.actor.flags, "midi-qol.concentration-data"),
 						templateId: workflow.templateId,
 						templateUuid: workflow.templateUuid
 					}
@@ -390,13 +393,13 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 				let [diceFormulas, damageTypes, damageTypeLabels] = getDamageFormulaAndType(weaponData, isVersatile);
 				let diceFormula = diceFormulas.join(" + ");
 				let damageType = damageTypes.join(", ");
-				let damageRoll = new Roll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod })
+				let damageRoll = new CONFIG.Dice.DamageRoll(diceFormula, { mod: weaponData.actor.system.abilities[attackData.ability].mod });
 
 				// Add critical damage dice
 				let critDice = [], critDie;
 				let damageRollDiceTerms = damageRoll.terms.filter(t => t.number > 0 && t.faces > 0);
 				for (let term of damageRollDiceTerms) {
-					critDie = new Die({ number: term.number, faces: term.faces });
+					critDie = new FoundryDie({ number: term.number, faces: term.faces });
 					critDice.push(critDie);
 				}
 				await damageRoll.alter(numHitAttacks, 0, { multiplyNumeric: true });
@@ -415,7 +418,14 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 					damageRoll = await damageRoll.evaluate();
 					await damageRoll.toMessage(
 						{
-							flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})${(numCrits > 0) ? ` (${game.i18n.localize("MAT.critIncluded")})` : ``}`
+							flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})${(numCrits > 0) ? ` (${game.i18n.localize("MAT.critIncluded")})` : ``}`,
+							flags: {
+								dnd5e: {
+									messageType: "roll",
+									roll: { type: "damage" },
+									targets: dnd5e.utils.getTargetDescriptors()
+								}
+							}
 						}
 					);
 				}

--- a/scripts/individualRolls.js
+++ b/scripts/individualRolls.js
@@ -1,5 +1,5 @@
 import { moduleName } from "./mobAttack.js";
-import { endGroupedMobTurn, getDamageFormulaAndType, sendChatMessage, getAttackBonus, callMidiMacro, getAttackData } from "./utils.js";
+import { endGroupedMobTurn, getDamageFormulaAndType, sendChatMessage, getAttackBonus, callMidiMacro, getAttackData, getDamageOptions } from "./utils.js";
 
 export async function rollMobAttackIndividually(data) {
 	// Temporarily disable DSN 3d dice from rolling, per settings
@@ -381,12 +381,12 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 					await new Promise(resolve => setTimeout(resolve, 300));
 					let damageOptions = {};
 					if (successfulAttackRolls[i].total - finalAttackBonus >= critThreshold && numCrits > 0) {
-						damageOptions = { "critical": true, "options": { "fastForward": true } };
+						damageOptions = getDamageOptions(true);
 						numCrits--
 					} else {
-						damageOptions = { "critical": false, "options": { "fastForward": true } };
+						damageOptions = getDamageOptions(false);
 					}
-					await weaponData.rollDamage(damageOptions);
+					await attackData.rollDamage(damageOptions.damage, damageOptions.dialog);
 				}
 			} else {
 				// Condense the damage rolls.

--- a/scripts/individualRolls.js
+++ b/scripts/individualRolls.js
@@ -423,7 +423,7 @@ export async function processIndividualDamageRolls(data, weaponData, finalAttack
 								dnd5e: {
 									messageType: "roll",
 									roll: { type: "damage" },
-									targets: dnd5e.utils.getTargetDescriptors()
+									targets: dnd5e.utils.getTargetDescriptors?.()
 								}
 							}
 						}

--- a/scripts/mobRules.js
+++ b/scripts/mobRules.js
@@ -1,5 +1,5 @@
 import { moduleName } from "./mobAttack.js";
-import { endGroupedMobTurn, getDamageFormulaAndType, calcD20Needed, calcAttackersNeeded, sendChatMessage, getAttackBonus, callMidiMacro } from "./utils.js";
+import { endGroupedMobTurn, getDamageFormulaAndType, calcD20Needed, calcAttackersNeeded, sendChatMessage, getAttackBonus, callMidiMacro, getAttackData, getDamageOptions } from "./utils.js";
 
 export async function rollMobAttack(data) {
 	// Temporarily disable DSN 3d dice from rolling, per settings
@@ -131,6 +131,8 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 
 	let showDamageRolls = game.user.getFlag(moduleName, "showIndividualDamageRolls") ?? game.settings.get(moduleName, "showIndividualDamageRolls");
 
+	const attackData = getAttackData(weaponData);
+
 	if (midi_QOL_Active) {
 		await new Promise(resolve => setTimeout(resolve, 100));
 
@@ -221,7 +223,8 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 		if (showDamageRolls) {
 			await new Promise(resolve => setTimeout(resolve, 100));
 			for (let i = 0; i < numHitAttacks; i++) {
-				await weaponData.rollDamage({ "critical": false, "options": { "fastForward": true } });
+				const damageOptions = getDamageOptions(false);
+				await attackData.rollDamage(damageOptions.damage, damageOptions.dialog);
 				await new Promise(resolve => setTimeout(resolve, 300));
 			}
 		} else {

--- a/scripts/mobRules.js
+++ b/scripts/mobRules.js
@@ -137,7 +137,7 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 		let [diceFormulas, damageTypes, damageTypeLabels] = getDamageFormulaAndType(weaponData, isVersatile);
 		let diceFormula = diceFormulas.join(" + ");
 		let damageType = damageTypes.join(", ");
-		let damageRoll = new Roll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod });
+		let damageRoll = new CONFIG.Dice.DamageRoll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod });
 		await damageRoll.alter(numHitAttacks, 0, { multiplyNumeric: true }).roll();
 
 		if (game.modules.get("dice-so-nice")?.active && game.settings.get(moduleName, "enableDiceSoNice")) {
@@ -161,13 +161,13 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 			damageRoll,
 			{
 				flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})`,
-				itemData: weaponData,
+				item: weaponData,
 				itemCardId: `new`
 			}
 		);
 
 		// prepare data for Midi's On Use Macro feature
-		if (game.settings.get(moduleName, "enableMidiOnUseMacro") && getProperty(weaponData, "flags.midi-qol.onUseMacroName")) {
+		if (game.settings.get(moduleName, "enableMidiOnUseMacro") && foundry.utils.getProperty(weaponData, "flags.midi-qol.onUseMacroName")) {
 			await new Promise(resolve => setTimeout(resolve, 300));
 			const macroData = {
 				actor: weaponData.actor,
@@ -198,7 +198,7 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 				uuid: workflow.uuid,
 				rollData: weaponData.actor.getRollData(),
 				tag: "OnUse",
-				concentrationData: getProperty(weaponData.actor.flags, "midi-qol.concentration-data"),
+				concentrationData: foundry.utils.getProperty(weaponData.actor.flags, "midi-qol.concentration-data"),
 				templateId: workflow.templateId,
 				templateUuid: workflow.templateUuid
 			}
@@ -229,12 +229,19 @@ export async function processMobRulesDamageRolls(data, weaponData, numHitAttacks
 			let [diceFormulas, damageTypes, damageTypeLabels] = getDamageFormulaAndType(weaponData, isVersatile);
 			let diceFormula = diceFormulas.join(" + ");
 			let damageType = damageTypes.join(", ");
-			let damageRoll = new Roll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod })
+			let damageRoll = new CONFIG.Dice.DamageRoll(diceFormula, { mod: weaponData.actor.system.abilities[weaponData.abilityMod].mod })
 			await damageRoll.alter(numHitAttacks, 0, { multiplyNumeric: true });
 			damageRoll = await damageRoll.evaluate();
 			await damageRoll.toMessage(
 				{
-					flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})`
+					flavor: `${weaponData.name} - ${game.i18n.localize("Damage Roll")} (${damageType})`,
+					flags: {
+						dnd5e: {
+							messageType: "roll",
+							roll: { type: "damage" },
+							targets: dnd5e.utils.getTargetDescriptors()
+						}
+					}
 				}
 			);
 		}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -47,7 +47,7 @@ export function getDamageOptions(allowCritical = true) {
 		};
 	} else {
 		return {
-			damage: { critical: { allow: true } },
+			damage: { isCritical: allowCritical },
 			dialog: { configure: false }
 		};
 	}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -15,7 +15,7 @@ export function getAttackData(item) {
 		if (attackActivity.damage) {
 			attackData.damage = {
 				parts: attackData.damage.parts.map(p => [
-					p.formula,
+					p.formula + (p.base && !/@mod\b/.test(p.formula) ? " + @mod" : ""),
 					p.types.first()
 				])
 			};
@@ -24,7 +24,7 @@ export function getAttackData(item) {
 				versatile.denomination ||= item.system.damage.base.steppedDenomination();
 				versatile.number ||= item.system.damage.base.number;
 				versatile.types = item.system.damage.base.types;
-				attackData.damage.versatile = versatile.formula;
+				attackData.damage.versatile = versatile.formula + (!/@mod\b/.test(versatile.formula) ? " + @mod" : "");
 			} else {
 				attackData.damage.versatile = "";
 			}

--- a/scripts/utils.js
+++ b/scripts/utils.js
@@ -9,6 +9,7 @@ export function getAttackData(item) {
 	let attackData;
 	if (!isDndV4OrNewer()) {
 		attackData = item.system;
+		attackData.rollDamage = item.rollDamage.bind(item);
 	} else {
 		const attackActivity = item.system?.activities?.find(a => a.type === "attack") || {};
 		attackData = {...attackActivity};
@@ -32,9 +33,24 @@ export function getAttackData(item) {
 			if (item.type === "spell" && item.level === 0) {
 				attackData.scaling = {mode: "cantrip"};
 			}
+			attackData.rollDamage = attackActivity.rollDamage.bind(attackActivity);
 		}
 	}
 	return attackData;
+}
+
+export function getDamageOptions(allowCritical = true) {
+	if (!isDndV4OrNewer()) {
+		return {
+			damage: { critical: allowCritical, options: { fastForward: true } },
+			dialog: {}
+		};
+	} else {
+		return {
+			damage: { critical: { allow: true } },
+			dialog: { configure: false }
+		};
+	}
 }
 
 // This is based in large part on midi-qol's callMacro method


### PR DESCRIPTION
Hi, this PR adds compatibility with dnd5e v4 while trying to maintain compatibility with older versions. I kinda see it more of a proposal than an actual PR, because I'm not sure if you planned to work on a v4-only version instead, which would probably look cleaner and be a little simpler to maintain... but surprisingly it would also be more work upfront.

What this does, summarized:

- Try to keep version checks at a minimum by using a "normalizing" function to get attack information in the old format from both old and new items;
- Update the ChatMessage creation to include target information (gives access to the new fancy dnd5e apply damage buttons);
- Update the MidiQOL calls to be compatible with their latest beta;
- Update deprecated references where possible.

Limitations: for the most part, this finds the first attack activity on an item to retrieve attack/damage info. Multiple attack activities are not considered yet, but they should be pretty rare.

Let me know what you think.